### PR TITLE
fix: support HTTPS proxy agent for REST requests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@binance/binance-cli",
-    "version": "1.0.4",
+    "version": "1.1.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@binance/binance-cli",
-            "version": "1.0.4",
+            "version": "1.1.1",
             "dependencies": {
                 "@binance/algo": "latest",
                 "@binance/alpha": "latest",
@@ -34,6 +34,7 @@
                 "@binance/wallet": "latest",
                 "commander": "^14.0.3",
                 "html-to-text": "^9.0.5",
+                "https-proxy-agent": "^7.0.6",
                 "inquirer": "^13.3.2",
                 "lodash": "^4.18.1",
                 "markdown-to-txt": "^2.0.1",
@@ -1115,9 +1116,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1135,9 +1133,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1155,9 +1150,6 @@
                 "ppc64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1175,9 +1167,6 @@
                 "s390x"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1195,9 +1184,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1215,9 +1201,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1663,6 +1646,15 @@
                 "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
             }
         },
+        "node_modules/agent-base": {
+            "version": "7.1.4",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+            "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 14"
+            }
+        },
         "node_modules/ajv": {
             "version": "6.14.0",
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
@@ -1886,7 +1878,6 @@
             "version": "4.4.3",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
             "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ms": "^2.1.3"
@@ -2632,6 +2623,19 @@
                 "entities": "^4.4.0"
             }
         },
+        "node_modules/https-proxy-agent": {
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+            "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "^7.1.2",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
         "node_modules/iconv-lite": {
             "version": "0.7.2",
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
@@ -2928,7 +2932,6 @@
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
             "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/mute-stream": {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
         "@binance/wallet": "latest",
         "commander": "^14.0.3",
         "html-to-text": "^9.0.5",
+        "https-proxy-agent": "^7.0.6",
         "inquirer": "^13.3.2",
         "lodash": "^4.18.1",
         "markdown-to-txt": "^2.0.1",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,6 +4,7 @@ import os, { platform, arch } from 'os';
 import { convert } from 'html-to-text';
 import { markdownToTxt } from 'markdown-to-txt';
 import type { ConfigurationRestAPI } from '@binance/common';
+import { HttpsProxyAgent } from 'https-proxy-agent';
 
 let stdin: any = null;
 const homeDir = os.homedir();
@@ -30,6 +31,30 @@ export function isHmacSecretKey(key: string): boolean {
 
 type CliConfiguration = ConfigurationRestAPI & {
     env: string | null;
+};
+
+const getProxyUrl = (): string | undefined => {
+    return (
+        process.env.HTTPS_PROXY ??
+        process.env.https_proxy ??
+        process.env.HTTP_PROXY ??
+        process.env.http_proxy
+    );
+};
+
+const withNetworkOptions = (configuration: CliConfiguration): CliConfiguration => {
+    const proxyUrl = getProxyUrl();
+
+    const networkOptions: Record<string, unknown> = {};
+    if (proxyUrl) {
+        networkOptions.proxy = false;
+        networkOptions.httpsAgent = new HttpsProxyAgent(proxyUrl);
+    }
+
+    return {
+        ...configuration,
+        ...networkOptions,
+    };
 };
 
 export const getCurrentProfile = (): string | null => {
@@ -162,14 +187,14 @@ export const getConfigurationRestAPI = (
     }
 
     if (creds.apiSecret && isHmacSecretKey(creds.apiSecret)) {
-        return {
+        return withNetworkOptions({
             ...creds,
-        };
+        });
     } else {
-        return {
+        return withNetworkOptions({
             privateKey: creds.apiSecret,
             ...creds,
-        };
+        });
     }
 };
 
@@ -181,7 +206,7 @@ export const decodeSelectedEntities = (str: string) => {
     };
     return convert(
         markdownToTxt(str)
-            .replace(/&#39;/g, "'")
+            .replace(/&#39;/g, '\'')
             .replace(/&#x3D;/g, '=')
             .replace(/&#x60;/g, '`')
             .replace(/&gt;/g, '>')


### PR DESCRIPTION
## Bug Description

`binance-cli` currently fails to access HTTPS Binance REST endpoints through a standard HTTP forward proxy set via environment variables such as `HTTPS_PROXY`.

In restricted-location environments, users often need to route Binance API calls through an allowed proxy. With the current CLI, proxied HTTPS requests can fail with:

```text
Request failed after 3 retries
AxiosError: timeout of 1000ms exceeded
```

## Root Cause

The CLI reads API credentials/profile configuration but does not translate standard proxy environment variables into a proper HTTPS CONNECT agent for the REST connectors.

Axios' plain `proxy` configuration is not reliable for this HTTPS-over-HTTP proxy use case. The request should disable Axios proxy handling and use an HTTPS proxy agent instead.

## Fix

- Add `https-proxy-agent` as a runtime dependency.
- Read proxy URLs from existing standard environment variables:
  - `HTTPS_PROXY` / `https_proxy`
  - `HTTP_PROXY` / `http_proxy`
- When a proxy URL is present, configure REST clients with:
  - `proxy: false`
  - `httpsAgent: new HttpsProxyAgent(proxyUrl)`

## How to Verify

1. Run without a proxy from a restricted-location host and confirm Binance returns the existing restricted-location response.
2. Run through an HTTP proxy that supports CONNECT:

```bash
HTTPS_PROXY=http://proxy.example:3128 \
binance-cli spot ticker-price --symbol BNBUSDT --profile <profile>
```

3. Verify signed endpoints still work through the proxy:

```bash
HTTPS_PROXY=http://proxy.example:3128 \
binance-cli wallet get-api-key-permission --profile <profile>
```

## Test Plan

- [x] `npm run build`
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] Manual verification of a public REST endpoint through an HTTP CONNECT proxy
- [x] Manual verification of a signed wallet endpoint through an HTTP CONNECT proxy

## Risk Assessment

Low — this only changes behavior when standard proxy environment variables are set. Existing users without those variables keep the current behavior.
